### PR TITLE
change: browser router was replaced by hash router

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { HashRouter as Router } from 'react-router-dom';
 import App from './App';
 
 const Root = () => (


### PR DESCRIPTION
 browser router was replaced by the hash router in reason that GH Pages doesn't support the browser router